### PR TITLE
Update archipelago_remastered.dme

### DIFF
--- a/archipelago_remastered.dme
+++ b/archipelago_remastered.dme
@@ -76,7 +76,13 @@
 #define CONTENTS_MILK 2
 #define CONTENTS_COCONUT 3
 
-
+#define FILE_DIR graphics/
+#define FILE_DIR graphics/building
+#define FILE_DIR graphics/farming
+#define FILE_DIR graphics/fish
+#define FILE_DIR graphics/items
+#define FILE_DIR graphics/metalwork
+#define FILE_DIR graphics/tools
 
 // BEGIN_PREFERENCES
 // END_PREFERENCES


### PR DESCRIPTION
Resolve compile-time error due to file_dir referencing for *.dmi files.